### PR TITLE
fix: improved cookies handling

### DIFF
--- a/layouts/partials/googleanalytics.html
+++ b/layouts/partials/googleanalytics.html
@@ -5,12 +5,26 @@
     {{- else }}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
       <script>
-        if (document.cookie.valueOf('eclipse_cookieconsent_status').search("allow") > -1) {
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '{{ . }}');
+        function gasetup() {
+            if (document.cookie.valueOf('eclipse_cookieconsent_status').search("allow") > -1 ) {
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '{{ . }}');
+            }
         }
+
+        // Listen for changes to the cookie consent status
+        // and re-run the GA setup if the user has accepted cookies
+        // This is necessary otherwise we'll lose the first page view
+        cookieStore.addEventListener('change', ({changed, deleted}) => {
+          if (changed.find(({name}) => name === 'eclipse_cookieconsent_status')) {
+            gasetup();
+          }
+        });
+
+        gasetup();
+
       </script>
     {{- end }}
   {{- end }}

--- a/layouts/partials/googleanalytics.html
+++ b/layouts/partials/googleanalytics.html
@@ -5,14 +5,15 @@
     {{- else }}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
       <script>
-        function gasetup() {
+        var gasetup;
+        (gasetup = function() {
             if (document.cookie.valueOf('eclipse_cookieconsent_status').search("allow") > -1 ) {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
               gtag('config', '{{ . }}');
             }
-        }
+        })();
 
         // Listen for changes to the cookie consent status
         // and re-run the GA setup if the user has accepted cookies
@@ -22,8 +23,6 @@
             gasetup();
           }
         });
-
-        gasetup();
 
       </script>
     {{- end }}


### PR DESCRIPTION
The current implementation of cookies handling results in not sending any data for the first page view. This is because, when the user accepts the cookie consent, there's no event listener that performs the setup. This PR listens to cookie changes events and performs the setup if the consent is accepted.

Documentation used: https://stackoverflow.com/questions/14344319/can-i-be-notified-of-cookie-changes-in-client-side-javascript

Please note that [CookieStore API](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore) is [not adopted by all browsers](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore#browser_compatibility) but will be in the future.

Tested on Chrome:
- as soon as the "Allow cookies" button is pressed I can see the GA event being fired.
- if "Decline" is pressed no event is fired

![image](https://github.com/user-attachments/assets/ec8f55cd-4dd1-4979-9655-e946797f9458)
