### PR TITLE
chore: Updated link to new 5.6.1 installer

### DIFF
--- a/layouts/shortcodes/pages/home/resources.html
+++ b/layouts/shortcodes/pages/home/resources.html
@@ -30,7 +30,7 @@ Olivier Goulet <olivier.goulet@eclipse-foundation.org>
       <div class="resources-item bg-primary">
         <h3 class="visible-xs visible-sm">Native Install</h3>
         <p>
-          <a href="https://www.eclipse.org/downloads/download.php?file=/kura/releases/5.6.0/kura_5.6.0_generic-aarch64_installer.deb">Download Kura</a>
+          <a href="https://www.eclipse.org/downloads/download.php?file=/kura/releases/5.6.1/kura_5.6.1_generic-aarch64_installer.deb">Download Kura</a>
           for your Raspberry Pi 3/4/5 Raspberry Pi OS (64 bit)
         </p>
         <p>


### PR DESCRIPTION
This pull request updates the download link for the Kura installer on the resources page to point to the latest version. This ensures users will access the most recent release when downloading Kura.

Resource update:

* Updated the Kura installer download link in `layouts/shortcodes/pages/home/resources.html` from version 5.6.0 to 5.6.1 for Raspberry Pi OS (64 bit).