### PR TITLE
docs: remove references to specific Kura version

### DIFF
--- a/layouts/shortcodes/pages/home/resources.html
+++ b/layouts/shortcodes/pages/home/resources.html
@@ -30,11 +30,11 @@ Olivier Goulet <olivier.goulet@eclipse-foundation.org>
       <div class="resources-item bg-primary">
         <h3 class="visible-xs visible-sm">Native Install</h3>
         <p>
-          <a href="https://www.eclipse.org/downloads/download.php?file=/kura/releases/5.6.1/kura_5.6.1_generic-aarch64_installer.deb">Download Kura</a>
-          for your Raspberry Pi 3/4/5 Raspberry Pi OS (64 bit)
+          <a href="https://github.com/eclipse-kura/kura/releases">Download Kura</a>
+          for your device.
         </p>
         <p>
-            To install, follow the <a href="https://eclipse-kura.github.io/kura/docs-release-5.6/getting-started/raspberry-pi-raspberryos-quick-start/">Install instructions</a>
+            To install, follow the <a href="https://eclipse-kura.github.io/kura/latest/getting-started/install-kura/">Install instructions</a>
         </p>
       </div>
       <div class="resources-item bg-primary">
@@ -43,13 +43,13 @@ Olivier Goulet <olivier.goulet@eclipse-foundation.org>
             Docker run: <b>docker run -d -p 8443:443 -t eclipse/kura</b>
         </p>
         <p>
-            Follow the <a href="https://eclipse-kura.github.io/kura/docs-release-5.6/getting-started/docker-quick-start/">documentation</a> for more info
+            Follow the <a href="https://eclipse-kura.github.io/kura/latest/getting-started/docker-quick-start/">documentation</a> for more info
         </p>
       </div>
       <div class="resources-item bg-primary">
         <h3 class="visible-xs visible-sm">Connect</h3>
         <p>
-            Use <a href="https://eclipse-kura.github.io/kura/docs-release-5.6/kura-wires/introduction/">Kura Wires</a> to visually connect your sensors and PLCs using a friendly web UI for data capture, processing and publishing. 
+            Use <a href="https://eclipse-kura.github.io/kura/latest/kura-wires/introduction/">Kura Wires</a> to visually connect your sensors and PLCs using a friendly web UI for data capture, processing and publishing. 
         </p>
       </div>
       <div class="resources-item bg-primary">


### PR DESCRIPTION
This pull request updates the resource links on the home page to point to the latest Kura release downloads and documentation, ensuring users always access the most up-to-date information.

Resource link updates:

* Updated the "Download Kura" link in the Native Install section to point to the official GitHub releases page, making it applicable for all devices instead of just Raspberry Pi.
* Changed installation and documentation links in the Native Install and Docker sections to reference the latest documentation instead of version-specific docs, ensuring users get current instructions. [[1]](diffhunk://#diff-5d6c53f9c1fe566a63bb90b28a013fe03f816fc7a3c6c30da12140684bcb0049L33-R37) [[2]](diffhunk://#diff-5d6c53f9c1fe566a63bb90b28a013fe03f816fc7a3c6c30da12140684bcb0049L46-R52)
* Updated the "Kura Wires" documentation link in the Connect section to the latest version, so users access the most recent features and instructions.